### PR TITLE
Print event arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,16 +7,25 @@ module.exports = function (emitter, type) {
   var emit = emitter && emitter.emit
   if (typeof emit !== 'function') return
 
-  emitter.emit = function (event) {
+  emitter.emit = function (event, ...args) {
     var end = Date.now()
     var diff = start === null ? 0 : end - start
     start = end
 
-    console.error(
-      chalk.yellow((type || emitter.constructor.name) + ':'),
-      chalk.white(event),
-      chalk.red('+' + diff + 'ms')
-    )
+    if (args.length > 0) {
+      console.error(
+        chalk.yellow((type || emitter.constructor.name) + ':'),
+        chalk.white(event),
+        chalk.white('(' + args.join(', ') + ')'),
+        chalk.red('+' + diff + 'ms')
+      )
+    } else {
+      console.error(
+        chalk.yellow((type || emitter.constructor.name) + ':'),
+        chalk.white(event),
+        chalk.red('+' + diff + 'ms')
+      )
+    }
 
     return emit.apply(this, arguments)
   }

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (emitter, type) {
       console.error(
         chalk.yellow((type || emitter.constructor.name) + ':'),
         chalk.white(event),
-        chalk.white('(' + args.join(', ') + ')'),
+        chalk.gray('(' + args.join(', ') + ')'),
         chalk.red('+' + diff + 'ms')
       )
     } else {

--- a/test.js
+++ b/test.js
@@ -27,7 +27,6 @@ emitter.emit('foo')
 
 process.stderr.write = function (chunk) {
   var line = strip(chunk.toString().trim())
-  console.log(line)
   var r = /EventEmitter: test \(hello, 42, \[object Object\], Error: test error\) \+\d+ms/
   assert.ok(r.test(line), line + ' !== ' + r.source)
   process.stderr.write = stderrWrite

--- a/test.js
+++ b/test.js
@@ -27,6 +27,21 @@ emitter.emit('foo')
 
 process.stderr.write = function (chunk) {
   var line = strip(chunk.toString().trim())
+  console.log(line)
+  var r = /EventEmitter: test \(hello, 42, \[object Object\], Error: test error\) \+\d+ms/
+  assert.ok(r.test(line), line + ' !== ' + r.source)
+  process.stderr.write = stderrWrite
+  stderrWrite.apply(this, arguments)
+}
+
+emitter = new EventEmitter()
+eventDebug(emitter)
+emitter.emit('test', 'hello', 42, { object: true }, new Error('test error'))
+
+// *****
+
+process.stderr.write = function (chunk) {
+  var line = strip(chunk.toString().trim())
   var r = /MyEmitter: bar \+\d+ms/
   assert.ok(r.test(line), line + ' !== ' + r.source)
   process.stderr.write = stderrWrite
@@ -49,7 +64,7 @@ process.stderr.write = function (chunk) {
   stderrWrite.apply(this, arguments)
 }
 
-emitter = { emit: function () {} }
+emitter = { emit: function () { } }
 eventDebug(emitter)
 emitter.emit('baz')
 


### PR DESCRIPTION
Heya :)

I've been using this module to debug some gnarly stream stuff, and I've found that I often want to see what value is emitted, especially on 'error' events.

This PR adds some really rudimentary printing of arguments which kind of does the trick - it's a bit annoying that objects get printed as `[object Object]`, but that could be fixed in a future iteration.

I added a test in the style of the previous ones, hope that works.

No worries if you don't have the time / don't want to merge this, I can still use my local copy - opening this in case it could be useful for others too.

Cheers! ✌️